### PR TITLE
Fix driver path rename in ChromeDriverManager

### DIFF
--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -40,9 +40,14 @@ class ChromeDriverManager(DriverManager):
     def install(self) -> str:
         driver_path = self._get_driver_binary_path(self.driver)
         os.chmod(driver_path, 0o755)
+
+        # rename extracted binary to have unified '.exe' extension across
+        # platforms so that Selenium behaves consistently
         path_regex = r"(?<=[\\/])[^\\/]+$"
-        driver_path = re.sub(path_regex, r"chromedriver.exe", driver_path)
-        return driver_path
+        new_driver_path = re.sub(path_regex, r"chromedriver.exe", driver_path)
+        if new_driver_path != driver_path:
+            os.replace(driver_path, new_driver_path)
+        return new_driver_path
 
     def get_os_type(self):
         os_type = super().get_os_type()


### PR DESCRIPTION
## Summary
- ensure Chrome driver binary is renamed on disk

## Testing
- `pytest tests/test_brave_driver.py::test_driver_with_ssl_verify_disabled_can_be_downloaded -q`
- `pytest tests/test_chrome_driver.py::test_chrome_manager_with_cache -q`
